### PR TITLE
add ScriptOJ online exercises links

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@
 * [下载EPUB](https://www.gitbook.com/download/epub/book/llh911001/mostly-adequate-guide-chinese)
 * [下载Mobi (Kindle)](https://www.gitbook.com/download/mobi/book/llh911001/mostly-adequate-guide-chinese)
 
+### 练习题
+
+你可以在 [ScriptOJ](https://scriptoj.com/problemsGroups/593a584f36387a3df1d87422) 在线进行本书的编程练习。
 
 # 目录
 


### PR DESCRIPTION
1. 在 README.md 当中添加练习专题链接。
2. 在有练习题的章节中添加链接可以直接链接到相应的题目。

因为添加的内容并不属于原文内容，所以在新增内容的开头都用了“译者注：”进行标注，并且用斜体进行区分。