### PR TITLE
support.js: fix bug caused by circle dependencies

### DIFF
--- a/code/part1_exercises/support.js
+++ b/code/part1_exercises/support.js
@@ -4,7 +4,7 @@
 //
 //
 function inspect(x) {
-  return (typeof x === 'function') ? inspectFn(x) : inspectArgs(x);
+  return (typeof x === 'function') ? inspectFn(x) : x;
 }
 
 function inspectFn(f) {


### PR DESCRIPTION
support.js文件中curry化函数后，调用 `toString` 报错，如下：
![image](https://user-images.githubusercontent.com/15937065/40003938-29f024c2-57c7-11e8-8a45-7aafb85c1864.png)


curry函数中的这段已经定义了 `toString` 方法：
![image](https://user-images.githubusercontent.com/15937065/40003851-f9c3114c-57c6-11e8-90f9-af5ec72f9532.png)

而且代码中存在循环依赖 （`inspect` 函数依赖于 `inspectArgs` 函数， `inspectArgs` 函数 依赖于 `inspect` 函数），解除依赖即可：
![image](https://user-images.githubusercontent.com/15937065/40004119-9875f1ec-57c7-11e8-80b5-3a59c8f2a8fe.png)
